### PR TITLE
feat: add login system for user and native clients

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,3 +1,4 @@
+/* eslint-env node */
 import express from 'express';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -14,8 +15,55 @@ app.use((req, _res, next) => {
   next();
 });
 
+app.use(express.json());
+
+const licenses = new Set();
+const users = new Map([["admin", "password"]]);
+
+app.get('/api/licenses', (_req, res) => {
+  res.json({ licenses: Array.from(licenses) });
+});
+
+app.post('/api/licenses', (req, res) => {
+  const { key } = req.body || {};
+  if (!key) {
+    return res.status(400).json({ error: 'missing key' });
+  }
+  licenses.add(key);
+  res.status(201).json({ key });
+});
+
+app.post('/api/login', (req, res) => {
+  const { username, password } = req.body || {};
+  if (!username || !password) {
+    return res.status(400).json({ error: 'missing credentials' });
+  }
+  const expected = users.get(username);
+  if (expected && expected === password) {
+    const token = Buffer.from(`${username}:${Date.now()}`).toString('base64');
+    return res.json({ token });
+  }
+  res.status(401).json({ error: 'invalid credentials' });
+});
+
+app.delete('/api/licenses/:key', (req, res) => {
+  const { key } = req.params;
+  if (licenses.delete(key)) {
+    return res.json({ ok: true });
+  }
+  res.status(404).json({ error: 'not found' });
+});
+
+app.post('/api/licenses/verify', (req, res) => {
+  const { key } = req.body || {};
+  if (!key) {
+    return res.status(400).json({ error: 'missing key' });
+  }
+  res.json({ valid: licenses.has(key) });
+});
+
 app.use(express.static(distPath));
-app.get('*', (req, res) => {
+app.get('*', (_req, res) => {
   res.sendFile(path.join(distPath, 'index.html'));
 });
 

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -5,6 +5,8 @@ import PlayerCard from "./components/PlayerCard";
 import Radar from "./components/Radar";
 import { getLatency, Latency } from "./components/latency";
 import MaskedIcon from "./components/maskedicon";
+import AdminDashboard from "./components/AdminDashboard";
+import UserDashboard from "./components/UserDashboard";
 
 const CONNECTION_TIMEOUT = 5000;
 
@@ -81,6 +83,13 @@ const loadSettings = () => {
 };
 
 const App = () => {
+  if (window.location.pathname.startsWith("/admin")) {
+    return <AdminDashboard />;
+  }
+  if (window.location.pathname.startsWith("/user")) {
+    return <UserDashboard />;
+  }
+
   const [averageLatency, setAverageLatency] = useState(0);
   const [playerArray, setPlayerArray] = useState([]);
   const [mapData, setMapData] = useState();

--- a/src/components/AdminDashboard.jsx
+++ b/src/components/AdminDashboard.jsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from "react";
+
+const AdminDashboard = () => {
+  const [licenses, setLicenses] = useState([]);
+  const [newKey, setNewKey] = useState("");
+
+  const loadLicenses = async () => {
+    try {
+      const res = await fetch("/api/licenses");
+      const data = await res.json();
+      setLicenses(data.licenses || []);
+    } catch (err) {
+      console.error("failed to load licenses", err);
+    }
+  };
+
+  useEffect(() => {
+    loadLicenses();
+  }, []);
+
+  const addLicense = async (e) => {
+    e.preventDefault();
+    const key = newKey.trim();
+    if (!key) return;
+    try {
+      await fetch("/api/licenses", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ key }),
+      });
+      setNewKey("");
+      loadLicenses();
+    } catch (err) {
+      console.error("failed to add license", err);
+    }
+  };
+
+  const deleteLicense = async (key) => {
+    try {
+      await fetch(`/api/licenses/${encodeURIComponent(key)}`, {
+        method: "DELETE",
+      });
+      loadLicenses();
+    } catch (err) {
+      console.error("failed to delete license", err);
+    }
+  };
+
+  return (
+    <div className="max-w-xl mx-auto p-4">
+      <h1 className="text-3xl font-bold mb-6 text-center">License Dashboard</h1>
+      <form onSubmit={addLicense} className="mb-6 flex">
+        <input
+          className="border rounded-l p-2 flex-1"
+          value={newKey}
+          onChange={(e) => setNewKey(e.target.value)}
+          placeholder="New license key"
+        />
+        <button className="bg-blue-500 text-white px-4 rounded-r" type="submit">
+          Add
+        </button>
+      </form>
+      <p className="mb-2 text-sm text-gray-600">Total licenses: {licenses.length}</p>
+      <table className="min-w-full bg-white shadow rounded">
+        <thead>
+          <tr>
+            <th className="p-2 text-left">Key</th>
+            <th className="p-2" />
+          </tr>
+        </thead>
+        <tbody>
+          {licenses.map((key) => (
+            <tr key={key} className="border-t">
+              <td className="p-2 font-mono break-all">{key}</td>
+              <td className="p-2 text-right">
+                <button
+                  className="text-red-500 hover:underline"
+                  type="button"
+                  onClick={() => deleteLicense(key)}
+                >
+                  Delete
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default AdminDashboard;

--- a/src/components/UserDashboard.jsx
+++ b/src/components/UserDashboard.jsx
@@ -1,0 +1,142 @@
+import { useState } from "react";
+
+const UserDashboard = () => {
+  const [token, setToken] = useState(localStorage.getItem("authToken") || "");
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [loginError, setLoginError] = useState(false);
+  const [license, setLicense] = useState(localStorage.getItem("licenseKey") || "");
+  const [status, setStatus] = useState(null); // null | "valid" | "invalid" | "error"
+
+  const verify = async (e) => {
+    e.preventDefault();
+    const key = license.trim();
+    if (!key) return;
+    try {
+      const res = await fetch("/api/licenses/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ key }),
+      });
+      const data = await res.json();
+      if (data.valid) {
+        localStorage.setItem("licenseKey", key);
+        setStatus("valid");
+      } else {
+        setStatus("invalid");
+      }
+    } catch (err) {
+      console.error("failed to verify license", err);
+      setStatus("error");
+    }
+  };
+
+  const login = async (e) => {
+    e.preventDefault();
+    try {
+      const res = await fetch("/api/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username, password }),
+      });
+      const data = await res.json();
+      if (data.token) {
+        localStorage.setItem("authToken", data.token);
+        setToken(data.token);
+        setUsername("");
+        setPassword("");
+        setLoginError(false);
+      } else {
+        setLoginError(true);
+      }
+    } catch (err) {
+      console.error("login failed", err);
+      setLoginError(true);
+    }
+  };
+
+  const logout = () => {
+    localStorage.removeItem("authToken");
+    setToken("");
+  };
+
+  const clear = () => {
+    localStorage.removeItem("licenseKey");
+    setLicense("");
+    setStatus(null);
+  };
+
+  return (
+    <div className="max-w-md mx-auto p-4">
+      <h1 className="text-3xl font-bold mb-6 text-center">User Panel</h1>
+      {!token ? (
+        <form onSubmit={login} className="flex flex-col">
+          <input
+            className="border p-2 mb-4 rounded"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            placeholder="Username"
+          />
+          <input
+            type="password"
+            className="border p-2 mb-4 rounded"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Password"
+          />
+          <button className="bg-blue-500 text-white px-4 py-2 rounded" type="submit">
+            Login
+          </button>
+          {loginError && <p className="text-red-500 mt-2">Invalid credentials.</p>}
+        </form>
+      ) : status === "valid" ? (
+        <div className="bg-green-100 p-4 rounded shadow">
+          <p className="mb-4">License <span className="font-mono break-all">{license}</span> is valid.</p>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              className="bg-red-500 text-white px-4 py-2 rounded"
+              onClick={clear}
+            >
+              Remove License
+            </button>
+            <button
+              type="button"
+              className="bg-gray-500 text-white px-4 py-2 rounded"
+              onClick={logout}
+            >
+              Logout
+            </button>
+          </div>
+        </div>
+      ) : (
+        <form onSubmit={verify} className="flex flex-col">
+          <input
+            className="border p-2 mb-4 rounded"
+            value={license}
+            onChange={(e) => setLicense(e.target.value)}
+            placeholder="Enter license key"
+          />
+          <button className="bg-blue-500 text-white px-4 py-2 rounded" type="submit">
+            Verify
+          </button>
+          {status === "invalid" && (
+            <p className="text-red-500 mt-2">Invalid license key.</p>
+          )}
+          {status === "error" && (
+            <p className="text-red-500 mt-2">Verification failed. Try again later.</p>
+          )}
+          <button
+            type="button"
+            className="mt-4 bg-gray-500 text-white px-4 py-2 rounded"
+            onClick={logout}
+          >
+            Logout
+          </button>
+        </form>
+      )}
+    </div>
+  );
+};
+
+export default UserDashboard;

--- a/usermode/src/dllmain.cpp
+++ b/usermode/src/dllmain.cpp
@@ -14,6 +14,13 @@ bool main()
     }
     LOG_INFO("config system initialization completed");
 
+    if (!auth::login(config_data.m_username, config_data.m_password))
+    {
+        std::this_thread::sleep_for(std::chrono::seconds(5));
+        return {};
+    }
+    LOG_INFO("login completed");
+
     if (!exc::setup())
     {
         std::this_thread::sleep_for(std::chrono::seconds(5));

--- a/usermode/src/utils/auth.cpp
+++ b/usermode/src/utils/auth.cpp
@@ -1,0 +1,47 @@
+#include "pch.hpp"
+#include "auth.hpp"
+
+namespace auth
+{
+    static size_t write_cb(void* contents, size_t size, size_t nmemb, void* userp)
+    {
+        const size_t total = size * nmemb;
+        std::string* s = static_cast<std::string*>(userp);
+        s->append(static_cast<char*>(contents), total);
+        return total;
+    }
+
+    bool login(const std::string& username, const std::string& password)
+    {
+        CURL* curl = curl_easy_init();
+        if (!curl)
+            return false;
+
+        std::string response;
+        const std::string payload = nlohmann::json{{"username", username}, {"password", password}}.dump();
+
+        curl_easy_setopt(curl, CURLOPT_URL, "http://localhost:8080/api/login");
+        curl_easy_setopt(curl, CURLOPT_POST, 1L);
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, payload.c_str());
+        struct curl_slist* headers = nullptr;
+        headers = curl_slist_append(headers, "Content-Type: application/json");
+        curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
+        curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
+        const CURLcode res = curl_easy_perform(curl);
+        curl_slist_free_all(headers);
+        curl_easy_cleanup(curl);
+        if (res != CURLE_OK)
+            return false;
+
+        try
+        {
+            const auto json = nlohmann::json::parse(response);
+            return json.contains("token");
+        }
+        catch (...)
+        {
+            return false;
+        }
+    }
+}

--- a/usermode/src/utils/auth.hpp
+++ b/usermode/src/utils/auth.hpp
@@ -1,0 +1,7 @@
+#pragma once
+#include <string>
+
+namespace auth
+{
+    bool login(const std::string& username, const std::string& password);
+}

--- a/usermode/src/utils/config.cpp
+++ b/usermode/src/utils/config.cpp
@@ -36,6 +36,8 @@ bool cfg::setup(config_data_t& config_data)
     "m_use_localhost": true,
     "m_local_ip": "192.168.x.x",
     "m_public_ip": "x.x.x.x",
+    "m_username": "user",
+    "m_password": "pass",
     "m_ui_base": "https://seuapp.netlify.app",
     "m_relay_host": "relay.seudominio.com",
     "m_relay_port": 22006,
@@ -57,6 +59,8 @@ bool cfg::setup(config_data_t& config_data)
         config_data.m_use_localhost = json_get_bool(parsed_data, "m_use_localhost", true);
         config_data.m_local_ip      = json_get_string(parsed_data, "m_local_ip");
         config_data.m_public_ip     = json_get_string(parsed_data, "m_public_ip");
+        config_data.m_username      = json_get_string(parsed_data, "m_username");
+        config_data.m_password      = json_get_string(parsed_data, "m_password");
 
         // Optional production fields
         config_data.m_ui_base    = json_get_string(parsed_data, "m_ui_base");

--- a/usermode/src/utils/config.hpp
+++ b/usermode/src/utils/config.hpp
@@ -5,6 +5,8 @@ struct config_data_t
     bool m_use_localhost{};
     std::string m_local_ip{};
     std::string m_public_ip{}; // may be domain or IP
+    std::string m_username{};
+    std::string m_password{};
 
     // Optional (production): separate relay and UI configuration
     std::string m_ui_base{};     // e.g. https://seuapp.netlify.app

--- a/usermode/usermode.hpp
+++ b/usermode/usermode.hpp
@@ -27,6 +27,7 @@
 #include "utils/exception.hpp"
 #include "utils/address.hpp"
 #include "utils/memory.hpp"
+#include "utils/auth.hpp"
 
 /* core */
 #include "core/interfaces.hpp"

--- a/usermode/usermode.vcxproj
+++ b/usermode/usermode.vcxproj
@@ -53,6 +53,7 @@
     <ClInclude Include="src\utils\memory.hpp" />
     <ClInclude Include="src\utils\exception.hpp" />
     <ClInclude Include="src\utils\utils.hpp" />
+    <ClInclude Include="src\utils\auth.hpp" />
     <ClInclude Include="usermode.hpp" />
     <ClInclude Include="src\pch.hpp" />
   </ItemGroup>
@@ -76,6 +77,7 @@
     <ClCompile Include="src\utils\exception.cpp" />
     <ClCompile Include="src\utils\memory.cpp" />
     <ClCompile Include="src\utils\utils.cpp" />
+    <ClCompile Include="src\utils\auth.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="readme.md" />


### PR DESCRIPTION
## Summary
- implement `/api/login` endpoint with token generation
- gate user dashboard behind login form with token storage and logout controls
- extend C++ usermode client to read credentials and authenticate via HTTP

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: `no-undef` errors in ws scripts)
- `npx eslint server.js src/components/UserDashboard.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68c7685ec72c8333ae0c99513a28d3d4